### PR TITLE
Fix: don't skip fresh installs when appversion is empty

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -840,7 +840,7 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
 
     # app versioncheck
     appNewVersion=$(defaults read $appPath/Contents/Info.plist $versionKey)
-    if [[ -n $appNewVersion ]] && is-at-least $appNewVersion $appversion; then
+    if [[ -n $appNewVersion ]] && [[ -n $appversion ]] && is-at-least $appNewVersion $appversion; then
         printlog "Downloaded version of $name is $appNewVersion on versionKey $versionKey, same as installed."
         if [[ $INSTALL != "force" ]]; then
             message="$name, version $appNewVersion, is the latest version."
@@ -12789,7 +12789,7 @@ if [[ "$type" != "updateronly" && ($INSTALL == "force" || $IGNORE_APP_STORE_APPS
 fi
 if [[ -n $appNewVersion ]]; then
     printlog "Latest version of $name is $appNewVersion"
-    if is-at-least $appNewVersion $appversion; then
+    if [[ -n $appversion ]] && is-at-least $appNewVersion $appversion; then
         if [[ $DEBUG -ne 1 ]]; then
             printlog "There is no newer version available."
             if [[ $INSTALL != "force" ]]; then

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -487,7 +487,7 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
 
     # app versioncheck
     appNewVersion=$(defaults read $appPath/Contents/Info.plist $versionKey)
-    if [[ -n $appNewVersion ]] && is-at-least $appNewVersion $appversion; then
+    if [[ -n $appNewVersion ]] && [[ -n $appversion ]] && is-at-least $appNewVersion $appversion; then
         printlog "Downloaded version of $name is $appNewVersion on versionKey $versionKey, same as installed."
         if [[ $INSTALL != "force" ]]; then
             message="$name, version $appNewVersion, is the latest version."

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -214,7 +214,7 @@ if [[ "$type" != "updateronly" && ($INSTALL == "force" || $IGNORE_APP_STORE_APPS
 fi
 if [[ -n $appNewVersion ]]; then
     printlog "Latest version of $name is $appNewVersion"
-    if is-at-least $appNewVersion $appversion; then
+    if [[ -n $appversion ]] && is-at-least $appNewVersion $appversion; then
         if [[ $DEBUG -ne 1 ]]; then
             printlog "There is no newer version available."
             if [[ $INSTALL != "force" ]]; then


### PR DESCRIPTION
## Problem

When an app is **not installed**, `getAppVersion` leaves `$appversion` empty. The two "already up to date?" checks call:

```zsh
is-at-least $appNewVersion $appversion
```

with `$appversion` empty and **unquoted**. zsh's `is-at-least` defaults its actual-version argument to `$ZSH_VERSION` when that argument is null (`version=(${=2:-$ZSH_VERSION} 0)`). So for a fresh install the comparison silently became:

```
is-at-least <appNewVersion> <ZSH_VERSION e.g. 5.9>   # -> true
```

→ `There is no newer version available.` → `cleanupAndExit 0 "No newer version."` — the app is **never installed**, but the run exits `0` (success).

### Observed impact
Any **first-time** install silently no-ops while reporting success. Upgrades are unaffected (there `$appversion` is non-empty, so the comparison is real). This surfaced via a Jamf Self Service `orbstack` install that logged:

```
WARN  : orbstack : could not find OrbStack.app
INFO  : orbstack : appversion:
INFO  : orbstack : Latest version of OrbStack is 2.2.1
INFO  : orbstack : There is no newer version available.
REQ   : orbstack : ################## End Installomator, exit code 0
```

## Fix

Guard both checks with `[[ -n $appversion ]]`, so the skip-as-up-to-date path only fires when a version was actually read from an installed app. (Quoting alone is **not** sufficient — `is-at-least`'s `${=2:-$ZSH_VERSION}` substitutes `$ZSH_VERSION` even for an explicit empty string; the `-n` guard is the actual fix.)

- `fragments/main.sh` — pre-download version gate
- `fragments/functions.sh` — post-download verify gate (`installAppWithPath`)
- `Installomator.sh` — assembled output kept in sync

## Testing
- `zsh -n Installomator.sh` passes.
- Fresh-install path now proceeds past the version gate instead of exiting `0` without installing.

> Note: `build/Installomator.sh` is a generated artifact and is intentionally left out of this PR; regenerate it from `fragments/` as part of the release/tag.